### PR TITLE
Added "Developed by" credit for wp-admin section.

### DIFF
--- a/lib/functions/general.php
+++ b/lib/functions/general.php
@@ -114,3 +114,11 @@ function be_default_facebook_image( $attachment_id ) {
 	$attachment_id = 50;
 	return $attachment_id;
 }
+
+/** Adds credit information to the footer of the admin sections
+*/
+
+add_filter( 'admin_footer_text', 'bk_admin_footer_text' );
+function bk_admin_footer_text( $default_text ) {
+     return '<span id="footer-thankyou">Website developed by <a href="http://www.brandonkraft.net">Brandon Kraft</a><span> | Powered by <a href="http://www.wordpress.org">WordPress</a>';
+}


### PR DESCRIPTION
I've added this to mine. It adds a simple "Website developed by Brandon Kraft" to the footer of the /wp-admin/ backend linked to my site. Nothing fancy, but a little self-promotion never hurt anyone.

You'll obviously want to change who gets credited. :-)
